### PR TITLE
Support unzipping an artifact

### DIFF
--- a/lib/updat.dart
+++ b/lib/updat.dart
@@ -272,7 +272,7 @@ class _UpdatWidgetState extends State<UpdatWidget> {
     }
     // Open the file.
     try {
-      await openInstaller(installerFile!);
+      await openInstaller(installerFile!, widget.appName);
       if (widget.closeOnInstall) exit(0);
     } catch (e) {
       setState(() {

--- a/lib/updat.dart
+++ b/lib/updat.dart
@@ -249,7 +249,7 @@ class _UpdatWidgetState extends State<UpdatWidget> {
       // Download the file.
 
       try {
-        await downloadRelease(installerFile!, url);
+        await downloadRelease(installerFile!, url, widget.appName);
       } catch (e) {
         setState(() {
           status = UpdatStatus.error;

--- a/lib/utils/file_handler.dart
+++ b/lib/utils/file_handler.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:archive/archive_io.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'package:path/path.dart' as p;
@@ -21,17 +22,22 @@ Future<File> getDownloadFileLocation(
   return File(filePath);
 }
 
-Future<File> downloadRelease(File file, String url) async {
+Future<File> downloadRelease(File file, String url, String appName) async {
   var res = await http.get(
     Uri.parse(url),
   );
   if (res.statusCode == 200) {
     await file.writeAsBytes(res.bodyBytes);
+    if (file.path.endsWith("zip")) {
+      final outDir = Directory(p.join(p.dirname(file.path), appName));
+      outDir.createSync(recursive: true);
+      extractFileToDisk(file.absolute.path, outDir.absolute.path);
+    }
     // Return with new installed status
     return file;
   } else {
     throw Exception(
-      'There was an issue downloading the file, plese try again later.\n'
+      'There was an issue downloading the file, please try again later.\n'
       'Code ${res.statusCode}',
     );
   }

--- a/lib/utils/file_handler.dart
+++ b/lib/utils/file_handler.dart
@@ -43,8 +43,20 @@ Future<File> downloadRelease(File file, String url, String appName) async {
   }
 }
 
-Future<void> openInstaller(File file) async {
+Future<void> openInstaller(File file, String appName) async {
   if (file.existsSync()) {
+    if (file.path.endsWith("zip")) {
+      final outDir = Directory(p.join(p.dirname(file.path), appName));
+      file = File(
+          outDir.listSync().firstWhere((e) {
+            if (Platform.isWindows) {
+              return e.path.endsWith("exe");
+            } else {
+              return true;
+            }
+          }).path
+      );
+    }
     await openUri(Uri(path: file.absolute.path, scheme: 'file'));
   } else {
     throw Exception(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   http: ^0.13.4
   flutter_markdown: ^0.6.10+3
   window_manager: ^0.3.0
+  archive: ^3.3.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
If the file extension is zip, unzip the downloaded artifact first in the same directory, then run it.