### PR TITLE
Refactor chip themes and harden file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add `handleWindowClose` and `onBeforeClose` to `UpdatWindowManager` for custom close handling
 * Add `UpdatTranslations` for localizing default UI strings (<https://github.com/aguilaair/updat/issues/30>)
 * Add `UpdatController` for programmatic update re-checks
+* Refactor chip themes to shared helpers and add `UpdatChipBuilder` / `UpdatDialogBuilder` typedefs
+* Add `UpdatException` and harden zip/installer file handling
 * Update dependencies and raise minimum SDK to Dart 3.8 / Flutter 3.27
 
 ## 1.4.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Want to learn how to integrate Updat in your app?
 | **`currentVersion`**          | `String`                     | **Required**. Must be a semantic version. This is the current package's version.                                     | N/A     |
 | **`getLatestVersion`**        | `Future<String>`             | **Required**. Must be a semantic version. This should request the latest version to the server                       | N/A     |
 | **`getBinaryUrl`**            | `Future<String>`             | **Required**. This should provide the link download the binary for a certain app version. Arguments: `latestVersion` | N/A     |
-| **`appNme`**                  | `String`                     | **Required**. The Application's name. It is used to name the binaries when downloading.                              | N/A     |
+| **`appName`**                 | `String`                     | **Required**. The Application's name. It is used to name the binaries when downloading.                              | N/A     |
 | **`getChangelog`**            | `Future<String>`             | This will render a plain text view of the changelog.                                                                 | N/A     |
 | **`callback`**                | `void Function(UpdatStatus)` | A callback that is called when the UpdatStatus gets updated.                                                         | N/A     |
 | **`controller`**              | `UpdatController`            | Optional controller for programmatic update checks and actions.                                                        | N/A     |

--- a/lib/theme/chips/chip_common.dart
+++ b/lib/theme/chips/chip_common.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/updat_translations_scope.dart';
+import '../../updat_status.dart';
+
+enum UpdatChipVariant { elevated, flat }
+
+Widget updatProgressIcon() {
+  return const SizedBox(
+    width: 15,
+    height: 15,
+    child: CircularProgressIndicator(
+      strokeWidth: 2,
+    ),
+  );
+}
+
+void maybeStartSilentDownload(
+  UpdatStatus status,
+  void Function() startUpdate,
+) {
+  if (UpdatStatus.available == status ||
+      UpdatStatus.availableWithChangelog == status) {
+    startUpdate();
+  }
+}
+
+Widget buildChipButton({
+  required UpdatChipVariant variant,
+  required VoidCallback? onPressed,
+  required Widget icon,
+  required Widget label,
+}) {
+  switch (variant) {
+    case UpdatChipVariant.elevated:
+      return ElevatedButton.icon(
+        onPressed: onPressed,
+        icon: icon,
+        label: label,
+      );
+    case UpdatChipVariant.flat:
+      return TextButton.icon(
+        onPressed: onPressed,
+        icon: icon,
+        label: label,
+      );
+  }
+}
+
+bool _isStandardChipStatus(UpdatStatus status) {
+  return UpdatStatus.available == status ||
+      UpdatStatus.availableWithChangelog == status ||
+      UpdatStatus.downloading == status ||
+      UpdatStatus.readyToInstall == status ||
+      UpdatStatus.error == status;
+}
+
+Widget buildStandardStatusChip({
+  required BuildContext context,
+  required String? latestVersion,
+  required UpdatStatus status,
+  required UpdatChipVariant variant,
+  required void Function() openDialog,
+  required void Function() startUpdate,
+  required Future<void> Function() launchInstaller,
+}) {
+  final t = UpdatTranslationsScope.of(context);
+
+  if (UpdatStatus.available == status ||
+      UpdatStatus.availableWithChangelog == status) {
+    return Tooltip(
+      message: t.updateToVersion(latestVersion!.toString()),
+      child: buildChipButton(
+        variant: variant,
+        onPressed: openDialog,
+        icon: const Icon(Icons.system_update_alt_rounded),
+        label: Text(t.updateAvailable),
+      ),
+    );
+  }
+
+  if (UpdatStatus.downloading == status) {
+    return Tooltip(
+      message: t.pleaseWait,
+      child: buildChipButton(
+        variant: variant,
+        onPressed: () {},
+        icon: updatProgressIcon(),
+        label: Text(t.downloading),
+      ),
+    );
+  }
+
+  if (UpdatStatus.readyToInstall == status) {
+    return Tooltip(
+      message: t.clickToInstall,
+      child: buildChipButton(
+        variant: variant,
+        onPressed: launchInstaller,
+        icon: const Icon(Icons.check_circle),
+        label: Text(t.readyToInstall),
+      ),
+    );
+  }
+
+  if (UpdatStatus.error == status) {
+    return Tooltip(
+      message: t.updateErrorTooltip,
+      child: buildChipButton(
+        variant: variant,
+        onPressed: startUpdate,
+        icon: const Icon(Icons.warning),
+        label: Text(t.errorTryAgain),
+      ),
+    );
+  }
+
+  return Container();
+}
+
+Widget buildCheckForStatusChip({
+  required BuildContext context,
+  required String? latestVersion,
+  required UpdatStatus status,
+  required UpdatChipVariant variant,
+  required void Function() checkForUpdate,
+  required void Function() openDialog,
+  required void Function() startUpdate,
+  required Future<void> Function() launchInstaller,
+}) {
+  if (_isStandardChipStatus(status)) {
+    return buildStandardStatusChip(
+      context: context,
+      latestVersion: latestVersion,
+      status: status,
+      variant: variant,
+      openDialog: openDialog,
+      startUpdate: startUpdate,
+      launchInstaller: launchInstaller,
+    );
+  }
+
+  final t = UpdatTranslationsScope.of(context);
+
+  if (UpdatStatus.idle == status) {
+    return Tooltip(
+      message: t.clickToCheckForUpdates,
+      child: buildChipButton(
+        variant: variant,
+        onPressed: checkForUpdate,
+        icon: const Icon(Icons.refresh_rounded),
+        label: Text(t.checkForUpdates),
+      ),
+    );
+  }
+
+  if (UpdatStatus.upToDate == status) {
+    return Tooltip(
+      message: t.clickToCheckForUpdates,
+      child: buildChipButton(
+        variant: variant,
+        onPressed: checkForUpdate,
+        icon: const Icon(Icons.check_circle),
+        label: Text(t.upToDate),
+      ),
+    );
+  }
+
+  if (UpdatStatus.checking == status) {
+    return Tooltip(
+      message: t.pleaseWait,
+      child: buildChipButton(
+        variant: variant,
+        onPressed: () {},
+        icon: updatProgressIcon(),
+        label: Text(t.checkingForUpdates),
+      ),
+    );
+  }
+
+  return Container();
+}
+
+Widget buildSilentDownloadReadyChip({
+  required BuildContext context,
+  required UpdatStatus status,
+  required UpdatChipVariant variant,
+  required void Function() startUpdate,
+  required Future<void> Function() launchInstaller,
+}) {
+  maybeStartSilentDownload(status, startUpdate);
+
+  if (UpdatStatus.readyToInstall != status) {
+    return Container();
+  }
+
+  final t = UpdatTranslationsScope.of(context);
+
+  return Tooltip(
+    message: t.clickToInstall,
+    child: buildChipButton(
+      variant: variant,
+      onPressed: launchInstaller,
+      icon: const Icon(Icons.check_circle),
+      label: Text(t.updateReadyToInstall),
+    ),
+  );
+}

--- a/lib/theme/chips/default.dart
+++ b/lib/theme/chips/default.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../l10n/updat_translations_scope.dart';
-import '../../updat.dart';
+import '../../updat_status.dart';
+import 'chip_common.dart';
 
 Widget defaultChip({
   required BuildContext context,
@@ -14,58 +14,13 @@ Widget defaultChip({
   required Future<void> Function() launchInstaller,
   required void Function() dismissUpdate,
 }) {
-  final t = UpdatTranslationsScope.of(context);
-
-  if (UpdatStatus.available == status ||
-      UpdatStatus.availableWithChangelog == status) {
-    return Tooltip(
-      message: t.updateToVersion(latestVersion!.toString()),
-      child: ElevatedButton.icon(
-        onPressed: openDialog,
-        icon: const Icon(Icons.system_update_alt_rounded),
-        label: Text(t.updateAvailable),
-      ),
-    );
-  }
-
-  if (UpdatStatus.downloading == status) {
-    return Tooltip(
-      message: t.pleaseWait,
-      child: ElevatedButton.icon(
-        onPressed: () {},
-        icon: const SizedBox(
-          width: 15,
-          height: 15,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-          ),
-        ),
-        label: Text(t.downloading),
-      ),
-    );
-  }
-
-  if (UpdatStatus.readyToInstall == status) {
-    return Tooltip(
-      message: t.clickToInstall,
-      child: ElevatedButton.icon(
-        onPressed: launchInstaller,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.readyToInstall),
-      ),
-    );
-  }
-
-  if (UpdatStatus.error == status) {
-    return Tooltip(
-      message: t.updateErrorTooltip,
-      child: ElevatedButton.icon(
-        onPressed: startUpdate,
-        icon: const Icon(Icons.warning),
-        label: Text(t.errorTryAgain),
-      ),
-    );
-  }
-
-  return Container();
+  return buildStandardStatusChip(
+    context: context,
+    latestVersion: latestVersion,
+    status: status,
+    variant: UpdatChipVariant.elevated,
+    openDialog: openDialog,
+    startUpdate: startUpdate,
+    launchInstaller: launchInstaller,
+  );
 }

--- a/lib/theme/chips/default_with_check_for.dart
+++ b/lib/theme/chips/default_with_check_for.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../l10n/updat_translations_scope.dart';
-import '../../updat.dart';
+import '../../updat_status.dart';
+import 'chip_common.dart';
 
 Widget defaultChipWithCheckFor({
   required BuildContext context,
@@ -14,97 +14,14 @@ Widget defaultChipWithCheckFor({
   required Future<void> Function() launchInstaller,
   required void Function() dismissUpdate,
 }) {
-  final t = UpdatTranslationsScope.of(context);
-
-  if (UpdatStatus.available == status ||
-      UpdatStatus.availableWithChangelog == status) {
-    return Tooltip(
-      message: t.updateToVersion(latestVersion!.toString()),
-      child: ElevatedButton.icon(
-        onPressed: openDialog,
-        icon: const Icon(Icons.system_update_alt_rounded),
-        label: Text(t.updateAvailable),
-      ),
-    );
-  }
-
-  if (UpdatStatus.downloading == status) {
-    return Tooltip(
-      message: t.pleaseWait,
-      child: ElevatedButton.icon(
-        onPressed: () {},
-        icon: const SizedBox(
-          width: 15,
-          height: 15,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-          ),
-        ),
-        label: Text(t.downloading),
-      ),
-    );
-  }
-
-  if (UpdatStatus.readyToInstall == status) {
-    return Tooltip(
-      message: t.clickToInstall,
-      child: ElevatedButton.icon(
-        onPressed: launchInstaller,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.readyToInstall),
-      ),
-    );
-  }
-
-  if (UpdatStatus.error == status) {
-    return Tooltip(
-      message: t.updateErrorTooltip,
-      child: ElevatedButton.icon(
-        onPressed: startUpdate,
-        icon: const Icon(Icons.warning),
-        label: Text(t.errorTryAgain),
-      ),
-    );
-  }
-
-  if (UpdatStatus.idle == status) {
-    return Tooltip(
-      message: t.clickToCheckForUpdates,
-      child: ElevatedButton.icon(
-        onPressed: checkForUpdate,
-        icon: const Icon(Icons.refresh_rounded),
-        label: Text(t.checkForUpdates),
-      ),
-    );
-  }
-
-  if (UpdatStatus.upToDate == status) {
-    return Tooltip(
-      message: t.clickToCheckForUpdates,
-      child: ElevatedButton.icon(
-        onPressed: checkForUpdate,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.upToDate),
-      ),
-    );
-  }
-
-  if (UpdatStatus.checking == status) {
-    return Tooltip(
-      message: t.pleaseWait,
-      child: ElevatedButton.icon(
-        onPressed: () {},
-        icon: const SizedBox(
-          width: 15,
-          height: 15,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-          ),
-        ),
-        label: Text(t.checkingForUpdates),
-      ),
-    );
-  }
-
-  return Container();
+  return buildCheckForStatusChip(
+    context: context,
+    latestVersion: latestVersion,
+    status: status,
+    variant: UpdatChipVariant.elevated,
+    checkForUpdate: checkForUpdate,
+    openDialog: openDialog,
+    startUpdate: startUpdate,
+    launchInstaller: launchInstaller,
+  );
 }

--- a/lib/theme/chips/default_with_silent_download.dart
+++ b/lib/theme/chips/default_with_silent_download.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../l10n/updat_translations_scope.dart';
-import '../../updat.dart';
+import '../../updat_status.dart';
+import 'chip_common.dart';
 
 Widget defaultChipWithSilentDownload({
   required BuildContext context,
@@ -14,23 +14,11 @@ Widget defaultChipWithSilentDownload({
   required Future<void> Function() launchInstaller,
   required void Function() dismissUpdate,
 }) {
-  final t = UpdatTranslationsScope.of(context);
-
-  if (UpdatStatus.available == status ||
-      UpdatStatus.availableWithChangelog == status) {
-    startUpdate();
-  }
-
-  if (UpdatStatus.readyToInstall == status) {
-    return Tooltip(
-      message: t.clickToInstall,
-      child: ElevatedButton.icon(
-        onPressed: launchInstaller,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.updateReadyToInstall),
-      ),
-    );
-  }
-
-  return Container();
+  return buildSilentDownloadReadyChip(
+    context: context,
+    status: status,
+    variant: UpdatChipVariant.elevated,
+    startUpdate: startUpdate,
+    launchInstaller: launchInstaller,
+  );
 }

--- a/lib/theme/chips/flat.dart
+++ b/lib/theme/chips/flat.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../l10n/updat_translations_scope.dart';
-import '../../updat.dart';
+import '../../updat_status.dart';
+import 'chip_common.dart';
 
 Widget flatChip({
   required BuildContext context,
@@ -14,58 +14,13 @@ Widget flatChip({
   required Future<void> Function() launchInstaller,
   required void Function() dismissUpdate,
 }) {
-  final t = UpdatTranslationsScope.of(context);
-
-  if (UpdatStatus.available == status ||
-      UpdatStatus.availableWithChangelog == status) {
-    return Tooltip(
-      message: t.updateToVersion(latestVersion!.toString()),
-      child: TextButton.icon(
-        onPressed: openDialog,
-        icon: const Icon(Icons.system_update_alt_rounded),
-        label: Text(t.updateAvailable),
-      ),
-    );
-  }
-
-  if (UpdatStatus.downloading == status) {
-    return Tooltip(
-      message: t.pleaseWait,
-      child: TextButton.icon(
-        onPressed: () {},
-        icon: const SizedBox(
-          width: 15,
-          height: 15,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-          ),
-        ),
-        label: Text(t.downloading),
-      ),
-    );
-  }
-
-  if (UpdatStatus.readyToInstall == status) {
-    return Tooltip(
-      message: t.clickToInstall,
-      child: TextButton.icon(
-        onPressed: launchInstaller,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.readyToInstall),
-      ),
-    );
-  }
-
-  if (UpdatStatus.error == status) {
-    return Tooltip(
-      message: t.updateErrorTooltip,
-      child: TextButton.icon(
-        onPressed: startUpdate,
-        icon: const Icon(Icons.warning),
-        label: Text(t.errorTryAgain),
-      ),
-    );
-  }
-
-  return Container();
+  return buildStandardStatusChip(
+    context: context,
+    latestVersion: latestVersion,
+    status: status,
+    variant: UpdatChipVariant.flat,
+    openDialog: openDialog,
+    startUpdate: startUpdate,
+    launchInstaller: launchInstaller,
+  );
 }

--- a/lib/theme/chips/flat_with_check_for.dart
+++ b/lib/theme/chips/flat_with_check_for.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../l10n/updat_translations_scope.dart';
-import '../../updat.dart';
+import '../../updat_status.dart';
+import 'chip_common.dart';
 
 Widget flatChipWithCheckFor({
   required BuildContext context,
@@ -14,97 +14,14 @@ Widget flatChipWithCheckFor({
   required Future<void> Function() launchInstaller,
   required void Function() dismissUpdate,
 }) {
-  final t = UpdatTranslationsScope.of(context);
-
-  if (UpdatStatus.available == status ||
-      UpdatStatus.availableWithChangelog == status) {
-    return Tooltip(
-      message: t.updateToVersion(latestVersion!.toString()),
-      child: TextButton.icon(
-        onPressed: openDialog,
-        icon: const Icon(Icons.system_update_alt_rounded),
-        label: Text(t.updateAvailable),
-      ),
-    );
-  }
-
-  if (UpdatStatus.downloading == status) {
-    return Tooltip(
-      message: t.pleaseWait,
-      child: TextButton.icon(
-        onPressed: () {},
-        icon: const SizedBox(
-          width: 15,
-          height: 15,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-          ),
-        ),
-        label: Text(t.downloading),
-      ),
-    );
-  }
-
-  if (UpdatStatus.readyToInstall == status) {
-    return Tooltip(
-      message: t.clickToInstall,
-      child: TextButton.icon(
-        onPressed: launchInstaller,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.readyToInstall),
-      ),
-    );
-  }
-
-  if (UpdatStatus.error == status) {
-    return Tooltip(
-      message: t.updateErrorTooltip,
-      child: TextButton.icon(
-        onPressed: startUpdate,
-        icon: const Icon(Icons.warning),
-        label: Text(t.errorTryAgain),
-      ),
-    );
-  }
-
-  if (UpdatStatus.idle == status) {
-    return Tooltip(
-      message: t.clickToCheckForUpdates,
-      child: TextButton.icon(
-        onPressed: checkForUpdate,
-        icon: const Icon(Icons.refresh_rounded),
-        label: Text(t.checkForUpdates),
-      ),
-    );
-  }
-
-  if (UpdatStatus.upToDate == status) {
-    return Tooltip(
-      message: t.clickToCheckForUpdates,
-      child: TextButton.icon(
-        onPressed: checkForUpdate,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.upToDate),
-      ),
-    );
-  }
-
-  if (UpdatStatus.checking == status) {
-    return Tooltip(
-      message: t.pleaseWait,
-      child: TextButton.icon(
-        onPressed: () {},
-        icon: const SizedBox(
-          width: 15,
-          height: 15,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-          ),
-        ),
-        label: Text(t.checkingForUpdates),
-      ),
-    );
-  }
-
-  return Container();
+  return buildCheckForStatusChip(
+    context: context,
+    latestVersion: latestVersion,
+    status: status,
+    variant: UpdatChipVariant.flat,
+    checkForUpdate: checkForUpdate,
+    openDialog: openDialog,
+    startUpdate: startUpdate,
+    launchInstaller: launchInstaller,
+  );
 }

--- a/lib/theme/chips/flat_with_silent_download.dart
+++ b/lib/theme/chips/flat_with_silent_download.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../l10n/updat_translations_scope.dart';
-import '../../updat.dart';
+import '../../updat_status.dart';
+import 'chip_common.dart';
 
 Widget flatChipWithSilentDownload({
   required BuildContext context,
@@ -14,23 +14,11 @@ Widget flatChipWithSilentDownload({
   required Future<void> Function() launchInstaller,
   required void Function() dismissUpdate,
 }) {
-  final t = UpdatTranslationsScope.of(context);
-
-  if (UpdatStatus.available == status ||
-      UpdatStatus.availableWithChangelog == status) {
-    startUpdate();
-  }
-
-  if (UpdatStatus.readyToInstall == status) {
-    return Tooltip(
-      message: t.clickToInstall,
-      child: TextButton.icon(
-        onPressed: launchInstaller,
-        icon: const Icon(Icons.check_circle),
-        label: Text(t.updateReadyToInstall),
-      ),
-    );
-  }
-
-  return Container();
+  return buildSilentDownloadReadyChip(
+    context: context,
+    status: status,
+    variant: UpdatChipVariant.flat,
+    startUpdate: startUpdate,
+    launchInstaller: launchInstaller,
+  );
 }

--- a/lib/theme/chips/floating_with_silent_download.dart
+++ b/lib/theme/chips/floating_with_silent_download.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../l10n/updat_translations_scope.dart';
 import '../../updat.dart';
+import 'chip_common.dart';
 
 Widget floatingExtendedChipWithSilentDownload({
   required BuildContext context,
@@ -16,10 +17,7 @@ Widget floatingExtendedChipWithSilentDownload({
 }) {
   final t = UpdatTranslationsScope.of(context);
 
-  if (UpdatStatus.available == status ||
-      UpdatStatus.availableWithChangelog == status) {
-    startUpdate();
-  }
+  maybeStartSilentDownload(status, startUpdate);
 
   if (UpdatStatus.readyToInstall == status) {
     return Card(

--- a/lib/updat.dart
+++ b/lib/updat.dart
@@ -6,9 +6,14 @@ import 'package:updat/l10n/updat_translations.dart';
 import 'package:updat/l10n/updat_translations_scope.dart';
 import 'package:updat/theme/chips/default.dart';
 import 'package:updat/theme/dialogs/default.dart';
+import 'package:updat/updat_builders.dart';
 import 'package:updat/updat_status.dart';
 import 'package:updat/utils/file_handler.dart';
 
+export 'package:updat/l10n/updat_translations.dart';
+export 'package:updat/updat_builders.dart';
+export 'package:updat/updat_controller.dart';
+export 'package:updat/updat_exception.dart';
 export 'package:updat/updat_status.dart';
 
 /// Imperative API for driving [UpdatWidget] and [UpdatWindowManager] from
@@ -133,31 +138,10 @@ class UpdatWidget extends StatefulWidget {
   final UpdatController? controller;
 
   /// This Function can be used to override the default chip shown when there is a new version available.
-  final Widget Function({
-    required BuildContext context,
-    required String? latestVersion,
-    required String appVersion,
-    required UpdatStatus status,
-    required void Function() checkForUpdate,
-    required void Function() openDialog,
-    required void Function() startUpdate,
-    required Future<void> Function() launchInstaller,
-    required void Function() dismissUpdate,
-  })? updateChipBuilder;
+  final UpdatChipBuilder? updateChipBuilder;
 
   /// This Function can be used to override the default dialog shown when there is a new version available. You must call `showDialog` yourself.
-  final void Function({
-    required BuildContext context,
-    required String? latestVersion,
-    required String appVersion,
-    required UpdatStatus status,
-    required String? changelog,
-    required void Function() checkForUpdate,
-    required void Function() openDialog,
-    required void Function() startUpdate,
-    required Future<void> Function() launchInstaller,
-    required void Function() dismissUpdate,
-  })? updateDialogBuilder;
+  final UpdatDialogBuilder? updateDialogBuilder;
 
   /// Get the url of the binary file to download provided with a certain version.
   final Future<String> Function(String? latestVersion) getBinaryUrl;

--- a/lib/updat_builders.dart
+++ b/lib/updat_builders.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:updat/updat_status.dart';
+
+typedef UpdatChipBuilder = Widget Function({
+  required BuildContext context,
+  required String? latestVersion,
+  required String appVersion,
+  required UpdatStatus status,
+  required void Function() checkForUpdate,
+  required void Function() openDialog,
+  required void Function() startUpdate,
+  required Future<void> Function() launchInstaller,
+  required void Function() dismissUpdate,
+});
+
+typedef UpdatDialogBuilder = void Function({
+  required BuildContext context,
+  required String? latestVersion,
+  required String appVersion,
+  required UpdatStatus status,
+  required String? changelog,
+  required void Function() checkForUpdate,
+  required void Function() openDialog,
+  required void Function() startUpdate,
+  required Future<void> Function() launchInstaller,
+  required void Function() dismissUpdate,
+});

--- a/lib/updat_exception.dart
+++ b/lib/updat_exception.dart
@@ -1,0 +1,8 @@
+class UpdatException implements Exception {
+  const UpdatException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'UpdatException: $message';
+}

--- a/lib/updat_window_manager.dart
+++ b/lib/updat_window_manager.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:universal_io/io.dart';
 
 import 'package:flutter/material.dart';
-import 'package:updat/l10n/updat_translations.dart';
 import 'package:updat/l10n/updat_translations_scope.dart';
 import 'package:updat/theme/chips/floating_with_silent_download.dart';
 import 'package:updat/updat.dart';
@@ -36,7 +35,7 @@ class UpdatWindowManager extends StatefulWidget {
     required this.child,
   });
 
-  ///  This function will be invoked to ckeck if there is a new version available. The return string must be a semantic version.
+  ///  This function will be invoked to check if there is a new version available. The return string must be a semantic version.
   final Future<String?> Function() getLatestVersion;
 
   ///  This function will be invoked if there is a new release to get the changes.
@@ -54,31 +53,10 @@ class UpdatWindowManager extends StatefulWidget {
   final UpdatController? controller;
 
   /// This Function can be used to override the default chip shown when there is a new version available.
-  final Widget Function({
-    required BuildContext context,
-    required String? latestVersion,
-    required String appVersion,
-    required UpdatStatus status,
-    required void Function() checkForUpdate,
-    required void Function() openDialog,
-    required void Function() startUpdate,
-    required Future<void> Function() launchInstaller,
-    required void Function() dismissUpdate,
-  })? updateChipBuilder;
+  final UpdatChipBuilder? updateChipBuilder;
 
   /// This Function can be used to override the default dialog shown when there is a new version available. You must call `showDialog` yourself.
-  final void Function({
-    required BuildContext context,
-    required String? latestVersion,
-    required String appVersion,
-    required UpdatStatus status,
-    required String? changelog,
-    required void Function() checkForUpdate,
-    required void Function() openDialog,
-    required void Function() startUpdate,
-    required Future<void> Function() launchInstaller,
-    required void Function() dismissUpdate,
-  })? updateDialogBuilder;
+  final UpdatDialogBuilder? updateDialogBuilder;
 
   /// Get the url of the binary file to download provided with a certain version.
   final Future<String> Function(String? latestVersion) getBinaryUrl;

--- a/lib/utils/file_handler.dart
+++ b/lib/utils/file_handler.dart
@@ -12,27 +12,30 @@ import 'package:updat/utils/open_link.dart';
 bool isZipArchive(String path) => p.extension(path).toLowerCase() == '.zip';
 
 File findInstallerInDirectory(Directory directory) {
-  final entries = directory.listSync();
-  if (entries.isEmpty) {
+  if (!directory.existsSync()) {
+    throw UpdatException('Installer directory does not exist: ${directory.path}');
+  }
+
+  final files = directory
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+
+  if (files.isEmpty) {
     throw UpdatException('No installer found in ${directory.path}');
   }
 
   if (Platform.isWindows) {
-    for (final entry in entries) {
-      if (entry is File && p.extension(entry.path).toLowerCase() == '.exe') {
-        return entry;
+    for (final file in files) {
+      if (p.extension(file.path).toLowerCase() == '.exe') {
+        return file;
       }
     }
     throw UpdatException('No Windows installer (.exe) found in ${directory.path}');
   }
 
-  for (final entry in entries) {
-    if (entry is File) {
-      return entry;
-    }
-  }
-
-  throw UpdatException('No installer file found in ${directory.path}');
+  return files.first;
 }
 
 Future<File> getDownloadFileLocation(

--- a/lib/utils/file_handler.dart
+++ b/lib/utils/file_handler.dart
@@ -5,14 +5,41 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:http/http.dart' as http;
 
+import 'package:updat/updat_exception.dart';
 import 'package:updat/utils/global_options.dart';
 import 'package:updat/utils/open_link.dart';
+
+bool isZipArchive(String path) => p.extension(path).toLowerCase() == '.zip';
+
+File findInstallerInDirectory(Directory directory) {
+  final entries = directory.listSync();
+  if (entries.isEmpty) {
+    throw UpdatException('No installer found in ${directory.path}');
+  }
+
+  if (Platform.isWindows) {
+    for (final entry in entries) {
+      if (entry is File && p.extension(entry.path).toLowerCase() == '.exe') {
+        return entry;
+      }
+    }
+    throw UpdatException('No Windows installer (.exe) found in ${directory.path}');
+  }
+
+  for (final entry in entries) {
+    if (entry is File) {
+      return entry;
+    }
+  }
+
+  throw UpdatException('No installer file found in ${directory.path}');
+}
 
 Future<File> getDownloadFileLocation(
     String release, String appName, String extension) async {
   final downloadDir = await getDownloadsDirectory();
   if (downloadDir == null) {
-    throw Exception('Unable to get downloads directory');
+    throw UpdatException('Unable to get downloads directory');
   }
   final filePath = p.join(
     downloadDir.absolute.path,
@@ -30,15 +57,14 @@ Future<File> downloadRelease(File file, String url, String appName) async {
   );
   if (res.statusCode == 200) {
     await file.writeAsBytes(res.bodyBytes);
-    if (file.path.endsWith("zip")) {
+    if (isZipArchive(file.path)) {
       final outDir = Directory(p.join(p.dirname(file.path), appName));
       outDir.createSync(recursive: true);
       extractFileToDisk(file.absolute.path, outDir.absolute.path);
     }
-    // Return with new installed status
     return file;
   } else {
-    throw Exception(
+    throw UpdatException(
       'There was an issue downloading the file, please try again later.\n'
       'Code ${res.statusCode}',
     );
@@ -46,23 +72,17 @@ Future<File> downloadRelease(File file, String url, String appName) async {
 }
 
 Future<void> openInstaller(File file, String appName) async {
-  if (file.existsSync()) {
-    if (file.path.endsWith("zip")) {
-      final outDir = Directory(p.join(p.dirname(file.path), appName));
-      file = File(
-          outDir.listSync().firstWhere((e) {
-            if (Platform.isWindows) {
-              return e.path.endsWith("exe");
-            } else {
-              return true;
-            }
-          }).path
-      );
-    }
-    await openUri(Uri(path: file.absolute.path, scheme: 'file'));
-  } else {
-    throw Exception(
-      'Installer does not exists, you have to download it first',
+  if (!file.existsSync()) {
+    throw const UpdatException(
+      'Installer does not exist, you have to download it first',
     );
   }
+
+  var installer = file;
+  if (isZipArchive(file.path)) {
+    final outDir = Directory(p.join(p.dirname(file.path), appName));
+    installer = findInstallerInDirectory(outDir);
+  }
+
+  await openUri(Uri(path: installer.absolute.path, scheme: 'file'));
 }

--- a/lib/utils/file_handler.dart
+++ b/lib/utils/file_handler.dart
@@ -87,5 +87,5 @@ Future<void> openInstaller(File file, String appName) async {
     installer = findInstallerInDirectory(outDir);
   }
 
-  await openUri(Uri(path: installer.absolute.path, scheme: 'file'));
+  await openUri(Uri.file(installer.absolute.path));
 }

--- a/lib/utils/open_link.dart
+++ b/lib/utils/open_link.dart
@@ -22,7 +22,7 @@ Future<void> openUri(Uri uri) async {
 
 Future<void> openPath(String url) async {
   if (Platform.isWindows) {
-    await Process.start('start', [url]);
+    await Process.start('cmd', ['/c', 'start', '', url]);
   } else if (Platform.isMacOS) {
     await Process.start('open', [url]);
   } else if (Platform.isLinux) {
@@ -46,7 +46,6 @@ Future<void> openCustom(
     await Process.run(
       customLocation,
       [path],
-      runInShell: true,
     );
   }
 }

--- a/lib/utils/open_link.dart
+++ b/lib/utils/open_link.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+
+import 'package:updat/updat_exception.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -6,7 +8,7 @@ Future<void> openLink(String url) async {
   if (await canLaunchUrlString(url)) {
     await launchUrlString(url);
   } else {
-    throw "Error";
+    throw UpdatException('Unable to open link: $url');
   }
 }
 
@@ -14,7 +16,7 @@ Future<void> openUri(Uri uri) async {
   if (await canLaunchUrl(uri)) {
     await launchUrl(uri);
   } else {
-    throw "Error";
+    throw UpdatException('Unable to open URI: $uri');
   }
 }
 
@@ -32,18 +34,17 @@ Future<void> openCustom(
   String path, {
   String? customLocation,
 }) async {
-  if (customLocation != null) {
-    return await openPath(path);
+  if (customLocation == null) {
+    return openPath(path);
   }
   if (Platform.isMacOS) {
     await Process.run(
-      "open",
-      ['-a $customLocation', path],
-      runInShell: true,
+      'open',
+      ['-a', customLocation, path],
     );
   } else {
     await Process.run(
-      customLocation!,
+      customLocation,
       [path],
       runInShell: true,
     );

--- a/test/file_handler_test.dart
+++ b/test/file_handler_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:updat/updat_exception.dart';
+import 'package:updat/utils/file_handler.dart';
+
+void main() {
+  group('file_handler', () {
+    test('isZipArchive is case-insensitive', () {
+      expect(isZipArchive('/tmp/app.zip'), isTrue);
+      expect(isZipArchive('/tmp/app.ZIP'), isTrue);
+      expect(isZipArchive('/tmp/app.Zip'), isTrue);
+      expect(isZipArchive('/tmp/app.exe'), isFalse);
+    });
+
+    test('findInstallerInDirectory throws when directory is empty', () {
+      final dir = Directory.systemTemp.createTempSync('updat_empty_');
+
+      expect(
+        () => findInstallerInDirectory(dir),
+        throwsA(isA<UpdatException>()),
+      );
+
+      dir.deleteSync(recursive: true);
+    });
+
+    test('findInstallerInDirectory returns first file on non-Windows', () {
+      final dir = Directory.systemTemp.createTempSync('updat_files_');
+      final installer = File('${dir.path}/installer.AppImage')
+        ..createSync(recursive: true);
+
+      expect(findInstallerInDirectory(dir).path, installer.path);
+
+      dir.deleteSync(recursive: true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extract shared chip logic into `chip_common.dart`; thin wrappers keep existing public API names
- Add `UpdatChipBuilder` / `UpdatDialogBuilder` typedefs and export them from `updat.dart`
- Add `UpdatException`; fix inverted `openCustom` logic in `open_link.dart`
- Harden `file_handler.dart`: case-insensitive `.zip` detection, safe installer lookup in extracted archives
- Fix README typo (`appNme` → `appName`) and doc comment typos

**Depends on:** #33 (which depends on #32)

## Test plan
- [x] `dart analyze lib/ test/` passes
- [x] `flutter test` — 10 tests pass (7 widget + 3 file_handler)
- [ ] No visual changes to default chip themes in example app


Made with [Cursor](https://cursor.com)